### PR TITLE
Bugfix: Write output as utf-8.

### DIFF
--- a/trestus/__init__.py
+++ b/trestus/__init__.py
@@ -1,3 +1,5 @@
+import codecs
+
 from argparse import ArgumentParser
 from datetime import datetime
 from os import environ, path
@@ -122,7 +124,7 @@ def main():
     else:
         template = env.get_template('trestus.html')
 
-    with open(args.output_path, 'w+') as f:
+    with codecs.open(args.output_path, 'w+', 'utf-8') as f:
         f.write(template.render(incidents=incidents, panels=panels,
                                 systems=systems, **template_data))
 


### PR DESCRIPTION
This allows trestus to also run with python 2.