### PR TITLE
Bugfix: Convert create_date to UTC before outputting.

### DIFF
--- a/trestus/__init__.py
+++ b/trestus/__init__.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser
 from datetime import datetime
+import pytz
 from os import environ, path
 from shutil import copy2
 from sys import exit
@@ -62,6 +63,7 @@ def main():
         cards = card_list.list_cards()
         cards.sort(key=lambda c: c.create_date, reverse=True)
         for card in cards:
+            card.parsed_date = card.create_date.astimezone(pytz.utc)
             severity = None
             for label in card.labels:
                 if not label.name.startswith('status:'):

--- a/trestus/templates/trestus.html
+++ b/trestus/templates/trestus.html
@@ -50,7 +50,7 @@
 				{% if incidents %}
 					{% for incident in incidents %}
 					<div class="incident">
-						<span class="date">{{ incident.create_date.strftime('%Y-%m-%d %H:%M:%S') }} UTC</span>
+						<span class="date">{{ incident.parsed_date.strftime('%Y-%m-%d %H:%M:%S') }} UTC</span>
 
 						{% if incident.closed %}
 							<span class="label operational float-right">resolved</span>


### PR DESCRIPTION
Otherwise, if the timezone of trello differs, the wrong times are printed.